### PR TITLE
Update fastly.toml.njk to support CLI v4+

### DIFF
--- a/resources/compute-js/fastly.toml.njk
+++ b/resources/compute-js/fastly.toml.njk
@@ -12,4 +12,4 @@ service_id = ""
 [local_server.backends]
 
 [scripts]
-  build = "npm run build"
+  build = "npx check-next-version && npx @fastly/compute-js-static-publish --build-static && $(npm bin)/webpack && $(npm bin)/js-compute-runtime ./bin/index.js ./bin/main.wasm"

--- a/resources/compute-js/fastly.toml.njk
+++ b/resources/compute-js/fastly.toml.njk
@@ -10,3 +10,6 @@ service_id = ""
 
 [local_server]
 [local_server.backends]
+
+[scripts]
+  build = "npm run build"


### PR DESCRIPTION
The Fastly CLI versions prior to v4.0.0 would call `npm run build` and this would have caused the following 'prebuild' step to have been executed...

https://github.com/fastly/next-compute-js/blob/main/resources/compute-js/package.json.njk#L9

But the CLI version v4+ now executes the following (which is dynamically added to the project's fastly.toml file:

```
$(npm bin)/webpack && $(npm bin)/js-compute-runtime ./bin/index.js ./bin/main.wasm
```

So the 'prebuild' step no longer executes, and causes an error when running `fastly compute serve` as instructed in the README.

I have found that changing the fastly.toml to be like the following works:

```
[scripts]
  build = "npm run build"
```

There is no need to specify `--skip-verification` on the CLI build/serve commands, as all the other project dependencies appear to be the same (e.g. webpack).

## UPDATE

@harmony7 commented internally on what the script should be so I've updated that now.

## Notes

CLI versions less than v4 will interpret the `[scripts.build]` entry in the fastly.toml as a 'custom' build script, and will display a message to the user asking them to be sure that executing the script is what they want to do.